### PR TITLE
Make the number of comments display correctly.

### DIFF
--- a/extension/astral-codex-eleven.js
+++ b/extension/astral-codex-eleven.js
@@ -48,6 +48,21 @@ class CommentApi {
   const LOG_TAG = '[Astral Codex Eleven]';
   console.info(LOG_TAG, 'Starting extension.');
 
+  // Hack to keep the displayed number of comments correct. As all of substack's
+  // API requests are redirected, it thinks there's only 1 comment. If we just
+  // change the content of the element, then substack overwrites our changes, so
+  // we clone the element and hide the original.
+  function makeSubstackProofClone(element) {
+    const cloned = element.cloneNode(true);
+    element.style.display = 'none';
+    element.after(cloned);
+  }
+
+  const likeHeader = document.querySelector('.post-header .like-button-container');
+  const likeFooter = document.querySelector('.post-footer .like-button-container');
+  makeSubstackProofClone(likeHeader.nextSibling);
+  makeSubstackProofClone(likeFooter.nextSibling);
+
   // Exfiltrate the _preloads.post.id global variable from the real page, using
   // a custom script append to the document body after the DOM is complete. This
   // is necessary because in the ISOLATED world we don't have direct access to

--- a/extension/astral-codex-eleven.js
+++ b/extension/astral-codex-eleven.js
@@ -58,10 +58,9 @@ class CommentApi {
     element.after(cloned);
   }
 
-  const likeHeader = document.querySelector('.post-header .like-button-container');
-  const likeFooter = document.querySelector('.post-footer .like-button-container');
-  makeSubstackProofClone(likeHeader.nextSibling);
-  makeSubstackProofClone(likeFooter.nextSibling);
+  for (const commentButton of document.querySelectorAll('.post-header .post-ufi-comment-button')) {
+    makeSubstackProofClone(commentButton);
+  }
 
   // Exfiltrate the _preloads.post.id global variable from the real page, using
   // a custom script append to the document body after the DOM is complete. This


### PR DESCRIPTION
Because of the redirect rules, substack always thinks there's only 1 comment. Because of this and its incessant need to constantly update the DOM, it incorrectly populates the element showing the number of comments and will replace it if you delete it. So, we clone the element before it's updated and then hide the original.