### PR TITLE
Add zen mode option.

### DIFF
--- a/extension/astral-codex-eleven.js
+++ b/extension/astral-codex-eleven.js
@@ -139,7 +139,7 @@ async function onLoad() {
   const commentFuncs = options.filter((e) => e.hasOwnProperty('processComment'));
   const optionApiFuncs = new OptionApiFuncs(headerFuncs, commentFuncs);
 
-  {
+  if (!(optionShadow.zenMode ?? false)) {
     const start = performance && performance.now();
     replaceComments(rootDiv, comments,
         {...REPLACE_COMMENTS_DEFAULT_OPTIONS, userId, commentApi, newFirst, optionApiFuncs});

--- a/extension/astral-codex-eleven.js
+++ b/extension/astral-codex-eleven.js
@@ -139,7 +139,7 @@ async function onLoad() {
   const commentFuncs = options.filter((e) => e.hasOwnProperty('processComment'));
   const optionApiFuncs = new OptionApiFuncs(headerFuncs, commentFuncs);
 
-  if (!(optionShadow.zenMode ?? false)) {
+  {
     const start = performance && performance.now();
     replaceComments(rootDiv, comments,
         {...REPLACE_COMMENTS_DEFAULT_OPTIONS, userId, commentApi, newFirst, optionApiFuncs});

--- a/extension/options.js
+++ b/extension/options.js
@@ -79,9 +79,22 @@ const templateOption = {
   processComment(commentData, commentElem) {}
 };
 
+const zenModeOption = {
+  key: 'zenMode',
+  default: false,
+  onStart(currentValue) {
+    addStyle(this.key);
+    setStyleEnabled(this.key, currentValue);
+  },
+  onValueChange(newValue) {
+    setStyleEnabled(this.key, newValue);
+  }
+}
+
 // All options should be added here.
 const optionArray = [
   // templateOption,
+  zenModeOption,
 ];
 
 const LOG_OPTION_TAG = '[Astral Codex Eleven] [Option]';

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -9,7 +9,11 @@
 
 <body class="dark">
     <div id="wrapper">
-        <div class="heading">Options</div>
+        <div class="heading">General</div>
+        <div id="zenMode" class="option">
+            <input type="checkbox" id="zenModeCheck" class="trigger check">
+            <label for="zenModeCheck">Zen mode</label>
+        </div>
     </div>
 </body>
 </html>

--- a/extension/styles.js
+++ b/extension/styles.js
@@ -5,6 +5,7 @@ const STYLES = {
   'zenMode': `
     .end-of-post-recommend-cta-container,
     .post-end-cta-full,
+    .subscribe-footer,
     .post-header .post-ufi,
     .post-footer,
     #comments-for-scroll,

--- a/extension/styles.js
+++ b/extension/styles.js
@@ -2,6 +2,19 @@
 
 // Holds dynamically enabled styling for use in options.
 const STYLES = {
+  'zenMode': `
+    .end-of-post-recommend-cta-container,
+    .post-end-cta-full,
+    .post-header .post-ufi,
+    .post-footer,
+    #comments-for-scroll,
+    .single-post-section,
+    .post div:has(.available-content) > div:not(.available-content),
+    .footer .footer-buttons,
+    .footer .footer-slogan-blurb {
+      display: none !important;
+    }
+  `,
 };
 
 // Adds a style tag with values from the given key in the STYLES dict.

--- a/extension/styles.js
+++ b/extension/styles.js
@@ -8,12 +8,17 @@ const STYLES = {
     .subscribe-footer,
     .post-header .post-ufi,
     .post-footer,
-    #comments-for-scroll,
     .single-post-section,
     .post div:has(.available-content) > div:not(.available-content),
     .footer .footer-buttons,
     .footer .footer-slogan-blurb {
       display: none !important;
+    }
+
+    .ext-comments {
+      border-top: 1px solid var(--color-detail-themed);
+      margin-top: 20px;
+      padding-top: 20px;
     }
   `,
 };


### PR DESCRIPTION
Adds an option to remove everything except the post content, including like buttons and post recommendation footers.

Thematically, comments should be removed, but it's probably better to have that as a separate option. It would also be good to have mouseover explanations of options, but I'll separate that out also.