### PR TITLE
Option limit depth

### DIFF
--- a/extension/astral-codex-eleven.js
+++ b/extension/astral-codex-eleven.js
@@ -100,6 +100,9 @@ class CommentApi {
   const commentOrder = commentSort === 'most_recent_first' ?
     CommentOrder.NEW_FIRST : CommentOrder.CHRONOLOGICAL;
 
+  const commentPathMatch = window.location.pathname.match(/\/p\/[\w-]+\/comment\/(\d+)/);
+  const rootCommentId = commentPathMatch?.[1];
+
   const commentsPage = document.querySelector('.comments-page');
   if (!commentsPage) {
     console.warn(LOG_TAG, "Element comments-page not found! Can't continue.");
@@ -121,8 +124,7 @@ class CommentApi {
     const start = performance && performance.now();
     // Note that I use ?no-filter& to bypass the filter rule that redirects
     // requests from the real page!
-    comments = await fetchComments(
-        `/api/v1/post/${postId}/comments/?no-filter&all_comments=true&sort=${commentSort}`);
+    comments = await fetchComments(postId, rootCommentId, commentSort);
     const duration = performance && Math.round(performance.now() - start);
     console.info(LOG_TAG, `fetch() completed in ${duration} ms.`)
   } catch (e) {

--- a/extension/ext-comments.css
+++ b/extension/ext-comments.css
@@ -165,6 +165,15 @@ a:focus {
   font-style: italic;
 }
 
+.ext-comments .comment .continue-thread-button {
+  display: inline-flex;
+  align-items: center;
+  height: 25px;
+  margin: 10px 0 0 0;
+  padding: 0 10px;
+  font-size: 12px;
+}
+
 /* Dates */
 
 .comment-timestamps {
@@ -292,4 +301,9 @@ a:focus {
 
 .ext-comments .comment-editor button.primary:focus {
   border-color: #0008 !important;
+}
+
+.ext-comments .comment .continue-thread-button:focus {
+  border-width: 2px;
+  padding: 0 9px;
 }

--- a/extension/ext-comments.js
+++ b/extension/ext-comments.js
@@ -430,6 +430,10 @@ class ExtCommentComponent {
     };
   }
 
+  getNumChildren() {
+    return this.childList.children.map(e => 1 + e.getNumChildren()).reduce((a, b) => a + b, 0);
+  }
+
   // Creates DOM nodes for the given comment text, and appends them to the
   // given parent element. This tries to mirror how Substack seems to process
   // comments:

--- a/extension/ext-comments.js
+++ b/extension/ext-comments.js
@@ -1,7 +1,11 @@
 'use strict';
 
-async function fetchComments(jsonPath) {
-  const fetchResponse = await fetch(jsonPath);
+async function fetchComments(postId, rootCommentId, commentSort) {
+  let url = `/api/v1/post/${postId}/comments/?no-filter&all_comments=true&sort=${commentSort}`;
+  if (rootCommentId) {
+    url += `&comment_id=${rootCommentId}`
+  }
+  const fetchResponse = await fetch(url);
   const responseJson = await fetchResponse.json();
   return responseJson?.comments;
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -39,10 +39,6 @@
       "matches": [
         "*://www.astralcodexten.com/*"
       ],
-      "exclude_matches": [
-        "*://www.astralcodexten.com/p/*/comment/*",
-        "*://www.astralcodexten.com/p/*/comments"
-      ],
       "css": [
         "ext-comments.css"
       ],

--- a/extension/options.js
+++ b/extension/options.js
@@ -205,10 +205,9 @@ const {
           if (commentComponent.commentData.children.length > 0) {
             const numChildren = commentComponent.getNumChildren();
             const buttonText = `Continue Thread (${numChildren} ${numChildren === 1 ? 'child' : 'children'}) →`;
-            const button = createElement(undefined, 'a', 'button outline continue-thread-button', buttonText);
+            const button = createElement(commentComponent.commentDiv, 'a', 'button outline continue-thread-button', buttonText);
             const id = commentComponent.commentData.id;
             button.href = `${this.basePostUrl}/comment/${id}`;
-            commentComponent.commentDiv.append(button);
           }
         }
       }

--- a/extension/options.js
+++ b/extension/options.js
@@ -178,6 +178,8 @@ const {
       this.dateFormatLong = new Intl.DateTimeFormat('en-US', {
         month: 'long', day: 'numeric', year: 'numeric', hour: '2-digit',
         minute: '2-digit', second: '2-digit', timeZoneName: 'short'});
+      const basePostUrlMatch = window.location.pathname.match(/\/p\/[\w-]+/);
+      this.basePostUrl = basePostUrlMatch?.[0] ?? window.location.pathname;
     },
     // Formats `date` as a string like "5 mins ago" or "1 hr ago" if it is
     // between `now` and `now` minus 24 hours, or returns undefined otherwise.
@@ -212,7 +214,7 @@ const {
 
       const timeDiv = commentComponent.commentDiv.querySelector(':scope > .comment-meta > .comment-timestamps');
       const postDateDiv = createElement(timeDiv, 'a', 'posted-date');
-      postDateDiv.href = `${document.location.pathname}/comment/${id}`;
+      postDateDiv.href = `${this.basePostUrl}/comment/${id}`;
       postDateDiv.rel = 'nofollow';
       this.createDate(postDateDiv, postDate);
 

--- a/extension/options.js
+++ b/extension/options.js
@@ -190,8 +190,8 @@ const {
   const forceLimitDepthOption = {
     key: 'forceLimitDepth',
     default: 8,
-    descriptionShort: 'asdf',
-    descriptionLong: 'asdf',
+    descriptionShort: 'Comment nesting limit',
+    descriptionLong: 'Limit to how deeply comments are nested before a "Continue Thread" button is shown. If 0, allow unlimited nesting.',
     onStart(currentValue) {
       const basePostUrlMatch = window.location.pathname.match(/\/p\/[\w-]+/);
       this.basePostUrl = basePostUrlMatch?.[0] ?? window.location.pathname;
@@ -202,10 +202,12 @@ const {
           const commentElem = commentComponent.threadDiv;
           commentElem.classList.add('hidden');
         } else if (commentComponent.depth === currentValue - 1) {
-          const button = createElement(undefined, 'a', 'button outline continue-thread-button', 'Continue Thread →');
-          const id = commentComponent.commentData.id;
-          button.href = `${this.basePostUrl}/comment/${id}`;
-          commentComponent.commentDiv.append(button);
+          if (commentComponent.commentData.children.length > 0) {
+            const button = createElement(undefined, 'a', 'button outline continue-thread-button', 'Continue Thread →');
+            const id = commentComponent.commentData.id;
+            button.href = `${this.basePostUrl}/comment/${id}`;
+            commentComponent.commentDiv.append(button);
+          }
         }
       }
     }

--- a/extension/options.js
+++ b/extension/options.js
@@ -203,7 +203,9 @@ const {
           commentElem.classList.add('hidden');
         } else if (commentComponent.depth === currentValue - 1) {
           if (commentComponent.commentData.children.length > 0) {
-            const button = createElement(undefined, 'a', 'button outline continue-thread-button', 'Continue Thread →');
+            const numChildren = commentComponent.getNumChildren();
+            const buttonText = `Continue Thread (${numChildren} ${numChildren === 1 ? 'child' : 'children'}) →`;
+            const button = createElement(undefined, 'a', 'button outline continue-thread-button', buttonText);
             const id = commentComponent.commentData.id;
             button.href = `${this.basePostUrl}/comment/${id}`;
             commentComponent.commentDiv.append(button);

--- a/extension/options.js
+++ b/extension/options.js
@@ -226,6 +226,30 @@ const {
     }
   };
 
+  const forceLimitDepthOption = {
+    key: 'forceLimitDepth',
+    default: 8,
+    descriptionShort: 'asdf',
+    descriptionLong: 'asdf',
+    onStart(currentValue) {
+      const basePostUrlMatch = window.location.pathname.match(/\/p\/[\w-]+/);
+      this.basePostUrl = basePostUrlMatch?.[0] ?? window.location.pathname;
+    },
+    processComment(currentValue, commentComponent) {
+      if (currentValue > 0) {
+        if (commentComponent.depth === currentValue) {
+          const commentElem = commentComponent.threadDiv;
+          commentElem.classList.add('hidden');
+        } else if (commentComponent.depth === currentValue - 1) {
+          const button = createElement(undefined, 'a', 'button outline continue-thread-button', 'Continue Thread →');
+          const id = commentComponent.commentData.id;
+          button.href = `${this.basePostUrl}/comment/${id}`;
+          commentComponent.commentDiv.append(button);
+        }
+      }
+    }
+  }
+
   // All options should be added here.
   const optionArray = [
     // templateOption,
@@ -235,6 +259,7 @@ const {
     collapseDepthOption,
     hideUsersOption,
     timeFormatOption,
+    forceLimitDepthOption,
   ];
 
   const LOG_TAG = '[Astral Codex Eleven] [Option]';

--- a/extension/options.js
+++ b/extension/options.js
@@ -199,8 +199,7 @@ const {
     processComment(currentValue, commentComponent) {
       if (currentValue > 0) {
         if (commentComponent.depth === currentValue) {
-          const commentElem = commentComponent.threadDiv;
-          commentElem.classList.add('hidden');
+          commentComponent.threadDiv.remove();
         } else if (commentComponent.depth === currentValue - 1) {
           if (commentComponent.commentData.children.length > 0) {
             const numChildren = commentComponent.getNumChildren();

--- a/extension/options.js
+++ b/extension/options.js
@@ -189,7 +189,7 @@ const {
 
   const forceLimitDepthOption = {
     key: 'forceLimitDepth',
-    default: 8,
+    default: 12,
     descriptionShort: 'Comment nesting limit',
     descriptionLong: 'Limit to how deeply comments are nested before a "Continue Thread" button is shown. If 0, allow unlimited nesting.',
     onStart(currentValue) {


### PR DESCRIPTION
Add an option to limit the comment nesting depth. Right now, it's purely internal and set to 12, which is when the width starts to become unwieldy (substack cuts it off at 11). Ideally you'd want it before you get any horizontal scrolling, though that depends on screen width.

Another reason to support this is that the old styling looks absolutely terrible if nesting more than 8 deep, as they extend past the inner container.